### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/ziphero.py
+++ b/ziphero.py
@@ -415,10 +415,10 @@ class ZipAutoRepair:
                         z.pwd = password.encode('utf-8')
                         # Attempt to read the first file to check password
                         z.testzip()
-                        logging.info(f"Successfully unlocked ZIP with password: {password}")
+                        logging.info("Successfully unlocked ZIP with a provided password.")
                         return password
                     except RuntimeError:
-                        logging.warning(f"Incorrect password: {password}")
+                        logging.warning("Incorrect password provided.")
                         continue
             logging.error("Failed to unlock ZIP file with provided password list.")
             return None


### PR DESCRIPTION
Fixes [https://github.com/JMitander/ZIPhero/security/code-scanning/2](https://github.com/JMitander/ZIPhero/security/code-scanning/2)

To fix the problem, we need to ensure that sensitive information, such as passwords, is not logged in clear text. Instead of logging the actual password, we can log a generic message indicating that the password was incorrect or that the ZIP file was successfully unlocked without revealing the password itself.

- Replace the logging of the incorrect password on line 421 with a generic message.
- Replace the logging of the successful password on line 418 with a generic message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
